### PR TITLE
Remove unwanted comments in .env

### DIFF
--- a/template/backend/.env.example
+++ b/template/backend/.env.example
@@ -1,7 +1,1 @@
-# Example of environment variables file
-# You need a .env file that will be gitignored
-
-# These are the environment variables needed for this application.
-# Change the values according to your environment:
-
 AUTH_SHARED_SECRET=auth-shared-secret


### PR DESCRIPTION
The .env is wrote with the comment you want and then appended with the content in template/backend/.env.example. The fix removes the additional comments from the .env.example file #22 